### PR TITLE
Add support for prometheus metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_le_challenge_type` | Different ACME Challenges. It is possible to use `httpChallenge` and `dnsChallenge`. (Default: `httpChallenge`) |
 | `traefik_le_email` | Required parameter to get the certificate Let’s Encrypt. (Default: `NULL`) |
 | `traefik_log_level` | Default: `WARN` . Alternative logging levels are `DEBUG`, `PANIC`, `FATAL`, `ERROR`, `WARN` and `INFO`. |
+| `traefik_enable_prometheus` | Default: `true` . Enables prometheus metrics endpoint. |
 
 ### Inventory variables
 #### HTTP service

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -31,3 +31,5 @@ traefik_tls_key: ""
 # Traefik static config
 traefik_log_level: 'WARN'
 traefik_api_debug: false
+
+traefik_enable_prometheus: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ lint: |
 platforms:
   - name: Ubuntu-18.04
     image: vstconsulting/images:ubuntu
-  - name: Centos-7
-    image: vstconsulting/images:centos7
+#  - name: Centos-7
+#    image: vstconsulting/images:centos7
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ lint: |
 platforms:
   - name: Ubuntu-18.04
     image: vstconsulting/images:ubuntu
-#  - name: Centos-7
-#    image: vstconsulting/images:centos7
+  - name: Centos-7
+    image: vstconsulting/images:centos7
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -46,6 +46,8 @@ entryPoints:
     address: ":443"
   traefik:
     address: ":8080"
+  metrics:
+    address: ":8082"
   test_1:
     address: ":8090"
 
@@ -62,6 +64,17 @@ certificatesResolvers:
       caServer: https://acme-staging-v02.api.letsencrypt.org/directory
       dnsChallenge:
         provider: route53
+
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addServicesLabels: true
+    addEntryPointsLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0
 
 api:
   dashboard: true

--- a/templates/traefik.yaml.j2
+++ b/templates/traefik.yaml.j2
@@ -6,6 +6,10 @@ entryPoints:
     address: ":443"
   traefik:
     address: ":8080"
+{% if traefik_enable_prometheus %}
+  metrics:
+    address: ":8082"
+{% endif %}
 {% if traefik_tcp_dynamic_config is defined and traefik_tcp_dynamic_config -%}
 {% for EntryPoint in traefik_tcp_dynamic_config %}
 {%- if EntryPoint['port'] is defined and EntryPoint['port'] %}
@@ -34,6 +38,19 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: http
 {%- endif %}
+{% endif %}
+
+{% if traefik_enable_prometheus -%}
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addServicesLabels: true
+    addEntryPointsLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0
 {% endif %}
 
 api:


### PR DESCRIPTION
Controlled by `traefik_enable_prometheus` variable.
Default is `true`.
