### PR TITLE
Add support custom providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_le_email` | Required parameter to get the certificate Let’s Encrypt. (Default: `NULL`) |
 | `traefik_log_level` | Default: `WARN` . Alternative logging levels are `DEBUG`, `PANIC`, `FATAL`, `ERROR`, `WARN` and `INFO`. |
 | `traefik_enable_prometheus` | Default: `true` . Enables prometheus metrics endpoint. |
+| `traefik_providers` | Default: `{}` . Setup other providers support. Key is provider name, value - provider settings. |
 
 ### Inventory variables
 #### HTTP service

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_le_challenge_type` | Different ACME Challenges. It is possible to use `httpChallenge` and `dnsChallenge`. (Default: `httpChallenge`) |
 | `traefik_le_email` | Required parameter to get the certificate Let’s Encrypt. (Default: `NULL`) |
 | `traefik_log_level` | Default: `WARN` . Alternative logging levels are `DEBUG`, `PANIC`, `FATAL`, `ERROR`, `WARN` and `INFO`. |
+| `traefik_enable_prometheus` | Default: `true` . Enables prometheus metrics endpoint. |
 
 ### Inventory variables
 #### HTTP service

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -32,4 +32,8 @@ traefik_tls_key: ""
 traefik_log_level: 'WARN'
 traefik_api_debug: false
 
+# Traefik prometheus support
 traefik_enable_prometheus: true
+
+# Enabling custom providers
+traefik_providers: {}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -31,3 +31,5 @@ traefik_tls_key: ""
 # Traefik static config
 traefik_log_level: 'WARN'
 traefik_api_debug: false
+
+traefik_enable_prometheus: true

--- a/molecule/default/inventory.yaml
+++ b/molecule/default/inventory.yaml
@@ -4,6 +4,12 @@ all:
     molecule_test_run: true
     traefik_log_level: 'DEBUG'
     traefik_api_debug: true
+    traefik_providers:
+      docker:
+        endpoint: "tcp://1.1.1.1:2376"
+        exposedByDefault: false
+        defaultRule: "Host(`{{'{{'}} .Name }}.example.com`)"
+        useBindPortIP: false
     traefik_http_dynamic_config:
       - name: 'test_1'
         services_url: 'http://172.16.1.10:9000'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ lint: |
 platforms:
   - name: Ubuntu-18.04
     image: vstconsulting/images:ubuntu
-  - name: Centos-7
-    image: vstconsulting/images:centos7
+#  - name: Centos-7
+#    image: vstconsulting/images:centos7
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ lint: |
 platforms:
   - name: Ubuntu-18.04
     image: vstconsulting/images:ubuntu
-#  - name: Centos-7
-#    image: vstconsulting/images:centos7
+  - name: Centos-7
+    image: vstconsulting/images:centos7
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -46,6 +46,8 @@ entryPoints:
     address: ":443"
   traefik:
     address: ":8080"
+  metrics:
+    address: ":8082"
   test_1:
     address: ":8090"
 
@@ -62,6 +64,17 @@ certificatesResolvers:
       caServer: https://acme-staging-v02.api.letsencrypt.org/directory
       dnsChallenge:
         provider: route53
+
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addServicesLabels: true
+    addEntryPointsLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0
 
 api:
   dashboard: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -55,6 +55,11 @@ providers:
   file:
     directory: /etc/traefik/dynamic/
     watch: false
+  docker:
+    defaultRule: Host(`{{ .Name }}.example.com`)
+    endpoint: tcp://1.1.1.1:2376
+    exposedByDefault: false
+    useBindPortIP: false
 
 certificatesResolvers:
   default_le_resolver:

--- a/templates/traefik.yaml.j2
+++ b/templates/traefik.yaml.j2
@@ -6,6 +6,10 @@ entryPoints:
     address: ":443"
   traefik:
     address: ":8080"
+{% if traefik_enable_prometheus %}
+  metrics:
+    address: ":8082"
+{% endif %}
 {% if traefik_tcp_dynamic_config is defined and traefik_tcp_dynamic_config -%}
 {% for EntryPoint in traefik_tcp_dynamic_config %}
 {%- if EntryPoint['port'] is defined and EntryPoint['port'] %}
@@ -34,6 +38,19 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: http
 {%- endif %}
+{% endif %}
+
+{% if traefik_enable_prometheus -%}
+metrics:
+  prometheus:
+    entryPoint: metrics
+    addServicesLabels: true
+    addEntryPointsLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0
 {% endif %}
 
 api:

--- a/templates/traefik.yaml.j2
+++ b/templates/traefik.yaml.j2
@@ -23,6 +23,12 @@ providers:
   file:
     directory: /etc/traefik/dynamic/
     watch: false
+{% for provider, config in traefik_providers.items() -%}
+{% if config is mapping %}
+  {{ provider }}:
+    {{ config | to_nice_yaml | indent(4) }}
+{%- endif %}
+{%- endfor %}
 
 {% if traefik_le_email -%}
 certificatesResolvers:


### PR DESCRIPTION
Provide support for enabling traefik providers via mapping `traefik_providers` where key is provider name and value is mapping of settings.