### PR TITLE
Add `tls_simple_acme` attribute and provide to override dashboard and metrics ports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_log_level` | Default: `WARN` . Alternative logging levels are `DEBUG`, `PANIC`, `FATAL`, `ERROR`, `WARN` and `INFO`. |
 | `traefik_enable_prometheus` | Default: `true` . Enables prometheus metrics endpoint. |
 | `traefik_providers` | Default: `{}` . Setup other providers support. Key is provider name, value - provider settings. |
+| `traefik_dashboard_port` | Default: `8080` . Insecure dashboard port. |
+| `traefik_metrics_port` | Default: `8080` . Insecure metrics port. |
 
 ### Inventory variables
 #### HTTP service

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ traefik_http_dynamic_config:
     services_url: 'http://172.16.1.10:9000'
     domain: 'testdomain2.example.com'
     tls: {}
+  # https with Let`s Encrypt auto domain cert + traefik ruled Host
+  - name: 'name_config__HTTPS__3'
+    services_url: 'http://172.16.1.10:9000'
+    raw_domain: >-
+      'Host(`testdomain3.example.com`, `testdomain4.example.com`)'
+    tls_simple_acme: true
 ```
 
 #### TCP service

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_enable_prometheus` | Default: `true` . Enables prometheus metrics endpoint. |
 | `traefik_providers` | Default: `{}` . Setup other providers support. Key is provider name, value - provider settings. |
 | `traefik_dashboard_port` | Default: `8080` . Insecure dashboard port. |
-| `traefik_metrics_port` | Default: `8080` . Insecure metrics port. |
+| `traefik_metrics_port` | Default: `8082` . Insecure metrics port for prometheus. |
 
 ### Inventory variables
 #### HTTP service

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -19,6 +19,9 @@ molecule_test_run: false
 traefik_path_bin: "/usr/bin"
 traefik_binary: "{{ traefik_path_bin }}/traefik_{{ traefik_distr_ver }}"
 
+# Dashboard port
+traefik_dashboard_port: 8080
+
 # LE
 traefik_le_caserver: "https://acme-v02.api.letsencrypt.org/directory"
 traefik_le_challenge_type: "httpChallenge"
@@ -34,6 +37,7 @@ traefik_api_debug: false
 
 # Traefik prometheus support
 traefik_enable_prometheus: true
+traefik_metrics_port: 8082
 
 # Enabling custom providers
 traefik_providers: {}

--- a/molecule/default/inventory.yaml
+++ b/molecule/default/inventory.yaml
@@ -4,6 +4,8 @@ all:
     molecule_test_run: true
     traefik_log_level: 'DEBUG'
     traefik_api_debug: true
+    traefik_metrics_port: 8081
+    traefik_dashboard_port: 8083
     traefik_providers:
       docker:
         endpoint: "tcp://1.1.1.1:2376"

--- a/molecule/default/inventory.yaml
+++ b/molecule/default/inventory.yaml
@@ -34,6 +34,11 @@ all:
         tls_resolver:
           main: 'testdomain2.example.com'
           sans: '*.testdomain2.example.com'
+      - name: 'test_5'
+        services_url: 'http://172.16.1.10:9000'
+        raw_domain: >-
+          'HostRegexp(`testdomain3.example.com`)'
+        tls_simple_acme: true
     traefik_tcp_dynamic_config:
       - name: 'test_1'
         port: 8090

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,3 +27,5 @@ provisioner:
     - --inventory=inventory.yaml
 verifier:
   name: testinfra
+  options:
+    vv: true

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -167,6 +167,7 @@ http:
           - main: testdomain.example.com
             sans:
               - '*.testdomain.example.com'
+
   services:
     test_1:
       loadBalancer:
@@ -238,8 +239,33 @@ http:
           - main: testdomain2.example.com
             sans:
               - '*.testdomain2.example.com'
+
   services:
     test_4:
+      loadBalancer:
+        servers:
+          - url: http://172.16.1.10:9000
+'''
+test_5_http = '''
+---
+http:
+  routers:
+    http_test_5:
+      rule: 'HostRegexp(`testdomain3.example.com`)'
+      entrypoints:
+        - http
+      service: test_5
+      middlewares:
+      - redirect-http-to-https
+    https_test_5:
+      rule: 'HostRegexp(`testdomain3.example.com`)'
+      entrypoints:
+        - https
+      service: test_5
+      tls:
+        certResolver: default_le_resolver
+  services:
+    test_5:
       loadBalancer:
         servers:
           - url: http://172.16.1.10:9000
@@ -271,6 +297,7 @@ check_files = {
     '/etc/traefik/dynamic/test_2_http.yaml': test_2_http,
     '/etc/traefik/dynamic/test_3_http.yaml': test_3_http,
     '/etc/traefik/dynamic/test_4_http.yaml': test_4_http,
+    '/etc/traefik/dynamic/test_5_http.yaml': test_5_http,
     '/etc/traefik/dynamic/test_1_tcp.yaml': test_1_tcp
 }
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -45,9 +45,9 @@ entryPoints:
   https:
     address: ":443"
   traefik:
-    address: ":8080"
+    address: ":8083"
   metrics:
-    address: ":8082"
+    address: ":8081"
   test_1:
     address: ":8090"
 

--- a/templates/traefik.http.dynamic.yaml.j2
+++ b/templates/traefik.http.dynamic.yaml.j2
@@ -10,7 +10,7 @@ http:
       entrypoints:
         - http
       service: {{ item.name }}
-{% if item.tls is defined or item.tls_resolver is defined %}
+{% if item.tls is defined or item.tls_resolver is defined or item.tls_simple_acme is defined %}
       middlewares:
       - redirect-http-to-https
     https_{{ item.name }}:
@@ -31,6 +31,9 @@ http:
           - main: {{ item.tls_resolver.main }}
             sans:
               - '{{ item.tls_resolver.sans }}'
+{% elif item.tls_simple_acme is defined and item.tls_simple_acme %}
+      tls:
+        certResolver: default_le_resolver
 {%- endif %}
 {%- endif %}
 

--- a/templates/traefik.yaml.j2
+++ b/templates/traefik.yaml.j2
@@ -5,10 +5,10 @@ entryPoints:
   https:
     address: ":443"
   traefik:
-    address: ":8080"
+    address: ":{{ traefik_dashboard_port }}"
 {% if traefik_enable_prometheus %}
   metrics:
-    address: ":8082"
+    address: ":{{ traefik_metrics_port }}"
 {% endif %}
 {% if traefik_tcp_dynamic_config is defined and traefik_tcp_dynamic_config -%}
 {% for EntryPoint in traefik_tcp_dynamic_config %}


### PR DESCRIPTION
Changelog:
* Provide to override dashboard and metrics ports.
* Add `tls_simple_acme` attribute for easier le tls configuration.
