### PR TITLE
Issue/update traefik

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -28,4 +28,4 @@ jobs:
 
       - name: Test with molecule with Ansible ${{ matrix.ansible-version }}
         run: |
-          tox -e py37-ansible${{ matrix.ansible-version }}
+          tox -e py38-ansible${{ matrix.ansible-version }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This ansible role intended for setting on the host Traefik.
 ### Defaults variables
 | **Inventory**               | **Description**             |
 | --------------------------- | --------------------------- |
-| `traefik_distr_ver` | The version of Traefik used. (Default: `v2.5.4`) |
+| `traefik_distr_ver` | The version of Traefik used. (Default: `v2.6.1`) |
 | `traefik_distr_os` | Operating system. (Default: `linux`) |
 | `traefik_distr_arch` | OS architecture. (Default: `amd64`) |
 | `traefik_url_release` | Traefik Archive URL. (Default: `https://github.com/containous/traefik/releases/download/v2.5.4/traefik_v2.5.4_linux_amd64.tar.gz`) |
@@ -21,6 +21,7 @@ This ansible role intended for setting on the host Traefik.
 | `traefik_dashboard_port` | Default: `8080` . Insecure dashboard port. |
 | `traefik_metrics_port` | Default: `8082` . Insecure metrics port for prometheus. |
 | `traefik_entrypoints_extra_parameters` | Configure parameters Traefik entrypoints . Uses for `http` and `https` entrypoints. (Default: `[]`). |
+| `traefik_http3` | Enable Support http3. Default: `true` |
 
 ### Inventory variables
 #### HTTP service

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 # Traefik info
-traefik_distr_ver: "v2.5.4"
+traefik_distr_ver: "v2.6.1"
 traefik_distr_os: "linux"
 traefik_distr_arch: "amd64"
 
@@ -44,3 +44,6 @@ traefik_providers: {}
 
 # Traefik parameters for entrypoints `http` and `https`
 traefik_entrypoints_extra_parameters: []
+
+# Advanced settings management
+traefik_http3: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ lint: |
   flake8 molecule/
   ansible-lint
 platforms:
-  - name: Ubuntu-18.04
+  - name: Ubuntu-20.04
     image: vstconsulting/images:ubuntu
   - name: Centos-7
     image: vstconsulting/images:centos7

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -8,7 +8,7 @@ traefik_service_content = '''
 [Unit]
 Description=Traefik
 Documentation=https://docs.traefik.io
-AssertFileIsExecutable=/usr/bin/traefik_v2.5.4
+AssertFileIsExecutable=/usr/bin/traefik_v2.6.1
 AssertPathExists=/etc/traefik/traefik.yaml
 
 [Service]
@@ -16,7 +16,7 @@ Environment="AWS_PROFILE=default"
 Environment="AWS_ACCESS_KEY_ID=token_access"
 Environment="AWS_SECRET_ACCESS_KEY=token_secret"
 Type=notify
-ExecStart=/usr/bin/traefik_v2.5.4
+ExecStart=/usr/bin/traefik_v2.6.1
 Restart=always
 WatchdogSec=1s
 
@@ -55,6 +55,7 @@ entryPoints:
         - 172.20.100.0/24
   https:
     address: ":443"
+    http3: {}
     forwardedHeaders:
         trustedIPs:
         - 127.0.0.1/32
@@ -109,6 +110,9 @@ api:
 
 log:
   level: DEBUG
+
+experimental:
+  http3: true
 '''
 default_crt = '''
 -----BEGIN CERTIFICATE-----
@@ -363,7 +367,7 @@ def test_check_distribution(host):
 
 
 def test_check_file_traefik(host):
-    assert host.file("/usr/bin/traefik_v2.5.4").exists
+    assert host.file("/usr/bin/traefik_v2.6.1").exists
 
     for file_path, content in check_files.items():
         file_obj = host.file(file_path)

--- a/templates/traefik.yaml.j2
+++ b/templates/traefik.yaml.j2
@@ -7,6 +7,9 @@ entryPoints:
 {%- endif %}
   https:
     address: ":443"
+{% if traefik_http3 %}
+    http3: {}
+{% endif %}
 {% if traefik_entrypoints_extra_parameters %}
     {{ traefik_entrypoints_extra_parameters | to_nice_yaml | indent(4) }}
 {%- endif %}
@@ -75,3 +78,8 @@ api:
 
 log:
   level: {{ traefik_log_level }}
+
+{% if traefik_http3 %}
+experimental:
+  http3: true
+{% endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py37-ansible{28,29,210}
+envlist = py38-ansible{28,29,210}
 skipsdist = true
 
 [testenv]
 passenv =
     DOCKER_HOST
 deps =
+    rich~=10.0.0
     molecule[ansible,lint,docker,test]~=3.0.5
     ansible28: ansible~=2.8.0
     ansible29: ansible~=2.9.0


### PR DESCRIPTION
Changelog:

- Updating the basic version of `traefik` to version `2.6.1`
- Added the ability to use `http3`